### PR TITLE
set div height to 100% instead of window.innerHeight

### DIFF
--- a/src/app/home-page/home-page.component.html
+++ b/src/app/home-page/home-page.component.html
@@ -1,5 +1,4 @@
 <div
-  [style]="GetStyle()"
   (wheel)="OnScroll($event)"
   (touchmove)="OnScroll($event)"
   (touchstart)="OnScroll($event)"
@@ -8,7 +7,6 @@
   >
   <canvas
     #actualCanvas
-    [style]="GetCanvasStyle()"
     (click)="onCanvasClick($event)"
     >
   </canvas>

--- a/src/app/home-page/home-page.component.scss
+++ b/src/app/home-page/home-page.component.scss
@@ -1,5 +1,12 @@
 div {
   overflow: hidden;
+  width: 100%;
+  height: 100%;
+}
+
+canvas {
+  width: 100%;
+  height: 100%;
 }
 
 .scroll-box {

--- a/src/app/home-page/home-page.component.ts
+++ b/src/app/home-page/home-page.component.ts
@@ -159,20 +159,6 @@ export class HomePageComponent implements OnInit {
       });
   }
 
-  GetStyle() {
-    return {
-      width: '100%',
-      height: `${window.innerHeight}px`,
-    }
-  }
-
-  GetCanvasStyle() {
-    return {
-      width: '100%',
-      height: `${window.innerHeight}px`,
-    }
-  }
-
   GetOffset(i: number, is_user_event: boolean): [number, number] {
     if (is_user_event) {
       const dx = this.userEventsOffset[i][0];


### PR DESCRIPTION
Somehow the height would still overflow on some browsers / devices.
Use 100% instead to deal with this corner case.
